### PR TITLE
build(project): ensure color is reset after echo command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,7 @@ $(ENVIRONMENTS_TARGETS):
 # Prints a message with color
 # $(call echo_msg, <emoji>, <action>, <object>, <context>)
 define echo_msg
-	echo "$(strip $(1)) ${COLOR_GREEN}$(strip $(2))${COLOR_RESET} ${COLOR_CYAN}$(strip $(3))${COLOR_RESET} $(strip $(4))"
+	echo "$(strip $(1)) ${COLOR_GREEN}$(strip $(2))${COLOR_RESET} ${COLOR_CYAN}$(strip $(3))${COLOR_RESET} $(strip $(4))${COLOR_RESET}"
 endef
 
 # Build go executable


### PR DESCRIPTION
Self explanatory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved terminal output formatting by ensuring colors are properly reset after each message, preventing unintended styling in subsequent outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->